### PR TITLE
Handle non-JSON values

### DIFF
--- a/src/storage.js
+++ b/src/storage.js
@@ -30,7 +30,7 @@ class Storage {
         try {
             return JSON.parse(value);
         } catch (e) {
-             _descEmitter.emit('error', 'Unable to parse value as JSON for "' + key + '" from ' + this.type + ' storage.');
+             _descEmitter.emit('success', 'Unable to parse value as JSON for "' + key + '" from ' + this.type + ' storage.');
              return value;
         }
     }

--- a/src/storage.js
+++ b/src/storage.js
@@ -27,7 +27,12 @@ class Storage {
             return storage.getItem(args.key);
         }, { returnByValue: true, args: { type: this.type, key: key } });
         _descEmitter.emit('success', 'Retrieve value for "' + key + '" from ' + this.type + ' storage.');
-        return JSON.parse(value);
+        try {
+            return JSON.parse(value);
+        } catch (e) {
+             _descEmitter.emit('error', 'Unable to parse value as JSON for "' + key + '" from ' + this.type + ' storage.');
+             return value;
+        }
     }
 
     async hasItem(key) {


### PR DESCRIPTION
There are cases where the value of a local storage item is not JSON, returning `JSON.parse(value)` can cause a successful retrieval to fail unnecessarily. This change will return JSON if parsable and the value if not.